### PR TITLE
Fix/#84 mod not saved when first created

### DIFF
--- a/frontend/src/types/Configuration.ts
+++ b/frontend/src/types/Configuration.ts
@@ -27,12 +27,3 @@ export interface GeneralConfig {
 export type FloorSkills = Record<Floor, Record<Room, WeightedSkill[]>>;
 
 export type Options = number & (ModOptions | GlobalOptions);
-
-export const DEFAULT_CONFIG: GeneralConfig = {
-    spawns: SpawnType.Consecutive,
-    curseSpawns: CurseSpawnType.Randomly,
-    pedestalSpawns: PedestalSpawnType.Randomly,
-    multiSpawners: MultiSpawnerType.Randomly,
-    options: ModOptions.SelectRandomItemOnEmpty,
-    startingSkills: [],
-};

--- a/frontend/src/utility/ConfigHelpers.ts
+++ b/frontend/src/utility/ConfigHelpers.ts
@@ -1,7 +1,4 @@
-import ModConfig, { DEFAULT_CONFIG, FloorSkills, Options } from '../types/Configuration';
-
-import { WeightedSkill } from '../types/Skill';
-import { Floor, Room } from '../types/enums/ConfigEnums';
+import { Options } from '../types/Configuration';
 import { ModOptions } from '../types/enums/ModOptions';
 import { GlobalOptions } from '../types/enums/GlobalOptions';
 
@@ -22,33 +19,4 @@ export function setOptionFlag(
         option &= ~flag;
     }
     return option;
-}
-
-export function generateEmptyMod(id: string): ModConfig {
-    return {
-        id,
-        info: { name: '', description: '' },
-        general: DEFAULT_CONFIG,
-        floorSkills: generateEmptyFloorSkills(),
-    };
-}
-
-export function generateEmptyFloorSkills(): FloorSkills {
-    return {
-        [Floor.AllFloors]: generateEmptyRoomSkills(),
-        [Floor.FirstFloor]: generateEmptyRoomSkills(),
-        [Floor.SecondFloor]: generateEmptyRoomSkills(),
-        [Floor.ThirdFloor]: generateEmptyRoomSkills(),
-        [Floor.Boss]: generateEmptyRoomSkills(),
-    };
-}
-
-export function generateEmptyRoomSkills(): Record<Room, WeightedSkill[]> {
-    return {
-        [Room.All]: [],
-        [Room.Free]: [],
-        [Room.Shop]: [],
-        [Room.Curse]: [],
-        [Room.Finale]: [],
-    };
 }

--- a/src-tauri/src/mod_handlers/mod_reader.rs
+++ b/src-tauri/src/mod_handlers/mod_reader.rs
@@ -54,9 +54,9 @@ pub fn decode_configuration(config_string: &String, id: &String) -> Result<ModCo
 fn build_mod_config(mod_info: &ModInfo,  config_array_original: &VecDeque<u32>, id: &String) -> Result<ModConfig, String> {
     let mut config_array = config_array_original.clone();
     config_array.pop_front();
-    let major = config_array.pop_front().unwrap();
-    let minor = config_array.pop_front().unwrap();
-    let patch = config_array.pop_front().unwrap();
+    let _major = config_array.pop_front().unwrap();
+    let _minor = config_array.pop_front().unwrap();
+    let _patch = config_array.pop_front().unwrap();
     let options = config_array.pop_front().unwrap();
     let spawns: SpawnType = FromPrimitive::from_u32(config_array.pop_front().unwrap()).unwrap();
     let curse_spawns: CurseSpawnType = FromPrimitive::from_u32(config_array.pop_front().unwrap()).unwrap();

--- a/src-tauri/src/mod_handlers/mod_util.rs
+++ b/src-tauri/src/mod_handlers/mod_util.rs
@@ -5,12 +5,12 @@ use crate::types::structs::RoomSkills;
 
 // Modified version of the decode from lib.rs
 pub fn string_to_u32_vec(config_string: &str) -> Result<VecDeque<u32>, String> {
-    let decodedResult = decode(config_string);
-    if decodedResult.is_err() {
+    let decoded_result = decode(config_string);
+    if decoded_result.is_err() {
         return Err(String::from("Invalid mod code"));
     }
 
-    let mut decoded = decodedResult.unwrap();
+    let mut decoded = decoded_result.unwrap();
 
     let mut result: VecDeque<u32> = VecDeque::new();
     // Read u8 values as u32 varints

--- a/src-tauri/src/types/enums.rs
+++ b/src-tauri/src/types/enums.rs
@@ -31,7 +31,7 @@ bitflags! {
         const NONE_SELECTED = 0;
         const CONFIG_PER_FLOOR = 1 << 0;
         const CONFIG_PER_ROOM = 1 << 1;
-        const REMOVE_HEALING_ITEMS = 1 << 2;
+        const SELECT_RANDOM_ITEM_ON_EMPTY = 1 << 2;
         const DISABLE_MENTOR_ABILITIES = 1 << 3;
         const DISABLE_GIFT_OF_INTERN = 1 << 4;
         const DISABLE_PINNED = 1 << 5;


### PR DESCRIPTION
Fixes #84 

- Creates the mod in the backend and automatically saves it.
- Removes unnecessary code in frontend.
- Updates `Options` enum in the backend to match the frontend version.
- Some minor rust cleanup to get rid of some of the warnings we were getting.